### PR TITLE
Fix the dockerfiles

### DIFF
--- a/back-office/Dockerfile
+++ b/back-office/Dockerfile
@@ -2,5 +2,5 @@ FROM nginx
 
 WORKDIR /usr/share/nginx/html
 
-ADD build .
+ADD . build
 EXPOSE 80

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-COPY backend /backend/
+COPY . /backend/
 
 ENV MARCEL_LOG_FILE=/backend/logs/backend.log
 WORKDIR /backend


### PR DESCRIPTION
Il y a quelques erreurs dans les Dockerfiles.
Au build, on obtient des erreurs telles que : 
ADD failed: stat /var/lib/docker/tmp/docker-builder627250588/build: no such file or directory
