### PR TITLE
:construction_worker: Push docker images only for master and tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,35 +157,49 @@ jobs:
       - run: ssh -o StrictHostKeyChecking=no -i integration_key.pem ubuntu@preprod.marcel.zenika.com "./MARCEL/deploy.sh"
       - run: rm -f integration_key.pem
 
+filters-all: &filters-all
+  tags:
+    only: /.*/
+filters-master: &filters-master
+  branches:
+    only:
+      - master
+
 workflows:
   version: 2
   build:
     jobs:
-       - debug_node
-       - debug_go
-       - build_backoffice
-       - build_frontend
-       - build_marcel
+       - debug_node:
+          filters: *filters-all
+       - debug_go:
+          filters: *filters-all
+       - build_backoffice:
+          filters: *filters-all
+       - build_frontend:
+          filters: *filters-all
+       - build_marcel:
+          filters: *filters-all
           # requires:
           #   - build_backoffice
           #   - build_frontend
-       - package_plugins
+       - package_plugins:
+          filters: *filters-all
        - docker_build_backoffice:
+          filters: *filters-all
           requires:
             - build_backoffice
        - docker_build_frontend:
+          filters: *filters-all
           requires:
             - build_frontend
        - docker_build_marcel:
+          filters: *filters-all
           requires:
             - build_marcel
        - deploy_integration:
+          filters: *filters-master
           requires:
             - docker_build_marcel
             - docker_build_backoffice
             - docker_build_frontend
             - package_plugins
-          filters:
-            branches:
-              only:
-                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,27 +19,25 @@ jobs:
       - run: go version
 
   build_backoffice:
+    working_directory: /usr/src/app/back-office
     docker:
       - image: circleci/node:12
     steps:
-      - checkout
+      - checkout:
+          path: /usr/src/app
       - restore_cache:
           keys:
-          - backoffice-dependencies-{{ checksum "back-office/package.json" }}
-      - run:
-          command: yarn
-          working_directory: back-office
+          - backoffice-dependencies-{{ checksum "package.json" }}
+      - run: yarn
       - save_cache:
           paths:
-            - back-office/node_modules
-          key: backoffice-dependencies-{{ checksum "back-office/package.json" }}
-      - run:
-          command: yarn build
-          working_directory: back-office
-      - save_cache:
-          paths:
-            - back-office/build
-          key: backoffice-build-{{ .Revision }}
+            - node_modules
+          key: backoffice-dependencies-{{ checksum "package.json" }}
+      - run: yarn build
+      # - save_cache:
+      #     paths:
+      #       - back-office/build
+      #     key: backoffice-build-{{ .Revision }}
 
   build_frontend:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/node:12
-    working_directory: /home/node/app
+    working_directory: /home/circleci/app
     steps:
       - checkout
       - restore_cache:
@@ -47,7 +47,7 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/node:12
-    working_directory: /home/node/app
+    working_directory: /home/circleci/app
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,55 +20,53 @@ jobs:
 
   build_backoffice:
     <<: *defaults
-    working_directory: /home/circleci/app
     docker:
       - image: circleci/node:12
+    working_directory: /home/node/app
     steps:
       - checkout
-      - run:
-          working_directory: back-office
-          command: pwd
       - restore_cache:
           keys:
-          - backoffice-dependencies-{{ checksum "back-office/package.json" }}
+          - backoffice-deps-{{ checksum "back-office/package.json" }}
       - run:
-          working_directory: back-office
           command: yarn
+          working_directory: back-office
       - save_cache:
           paths:
-            - node_modules
-          key: backoffice-dependencies-{{ checksum "back-office/package.json" }}
+            - back-office/node_modules
+          key: backoffice-deps-{{ checksum "back-office/package.json" }}
       - run:
-          working_directory: back-office
           command: yarn build
+          working_directory: back-office
       - persist_to_workspace:
           root: .
           paths:
             - back-office/build
 
   build_frontend:
+    <<: *defaults
     docker:
       - image: circleci/node:12
+    working_directory: /home/node/app
     steps:
       - checkout
       - restore_cache:
           keys:
-          - frontend-dependencies-{{ checksum "frontend/package.json" }}
+          - frontend-deps-{{ checksum "frontend/package.json" }}
       - run:
           command: yarn
           working_directory: frontend
       - save_cache:
           paths:
             - frontend/node_modules
-          key: frontend-dependencies-{{ checksum "frontend/package.json" }}
+          key: frontend-deps-{{ checksum "frontend/package.json" }}
       - run:
           command: yarn build
           working_directory: frontend
-      - save_cache:
+      - persist_to_workspace:
+          root: .
           paths:
             - frontend/build
-          key: frontend-build-{{ .Revision }}
-
 
   build_marcel:
     <<: *defaults
@@ -105,42 +103,45 @@ jobs:
             - plugins.tar.gz
           key: plugins-package-{{ .Revision }}
 
-  docker_build_marcel:
+  docker_build_backoffice:
     <<: *defaults
-    working_directory: /tmp/app
     docker:
       - image: circleci/buildpack-deps:stable-curl
+    working_directory: /tmp/app
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: /tmp/app
+      - run:
+          command: ${CIRCLE_WORKING_DIRECTORY}/scripts/docker_build.sh zenika/marcel-backoffice
+          working_directory: back-office
+
+  docker_build_frontend:
+    <<: *defaults
+    docker:
+      - image: circleci/buildpack-deps:stable-curl
+    working_directory: /tmp/app
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: /tmp/app
+      - run:
+          command: ${CIRCLE_WORKING_DIRECTORY}/scripts/docker_build.sh zenika/marcel-frontend
+          working_directory: frontend
+
+  docker_build_marcel:
+    <<: *defaults
+    docker:
+      - image: circleci/buildpack-deps:stable-curl
+    working_directory: /tmp/app
     steps:
       - checkout
       - setup_remote_docker
       - attach_workspace:
           at: /tmp/app
       - run: ${CIRCLE_WORKING_DIRECTORY}/scripts/docker_build.sh zenika/marcel
-
-  docker_build_backoffice:
-    working_directory: back-office
-    docker:
-      - image: circleci/buildpack-deps:stable-curl
-    steps:
-      - checkout
-      - setup_remote_docker
-      - restore_cache:
-          keys:
-            - backoffice-build-{{ .Revision }}
-      - run: ${CIRCLE_WORKING_DIRECTORY}/scripts/docker_build.sh zenika/marcel-backoffice
-
-  docker_build_frontend:
-    working_directory: frontend
-    docker:
-      - image: circleci/buildpack-deps:stable-curl
-    steps:
-      - checkout
-      - setup_remote_docker
-      - restore_cache:
-          keys:
-            - frontend-build-{{ .Revision }}
-      - run:
-          command: ${CIRCLE_WORKING_DIRECTORY}/scripts/docker_build.sh zenika/marcel-frontend
 
   deploy_integration:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
 
   build_backoffice:
     <<: *defaults
-    working_directory: /usr/src/app
+    working_directory: /home/circleci/app
     docker:
       - image: circleci/node:12
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
       - restore_cache:
           keys:
           - backoffice-dependencies-{{ checksum "back-office/package.json" }}
-          - backoffice-dependencies-
       - run:
           command: yarn
           working_directory: back-office
@@ -50,7 +49,6 @@ jobs:
       - restore_cache:
           keys:
           - frontend-dependencies-{{ checksum "frontend/package.json" }}
-          - frontend-dependencies-
       - run:
           command: yarn
           working_directory: frontend
@@ -108,14 +106,14 @@ jobs:
     docker:
       - image: circleci/buildpack-deps:stable-curl
     steps:
+      - checkout
       - setup_remote_docker
       - attach_workspace:
           at: /tmp/app
-      - run: docker build -t zenika/marcel:dev .
-      - run: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-      - run: docker push zenika/marcel:dev
+      - run: ${CIRCLE_WORKING_DIRECTORY}/scripts/docker_build.sh zenika/marcel
 
   docker_build_backoffice:
+    working_directory: back-office
     docker:
       - image: circleci/buildpack-deps:stable-curl
     steps:
@@ -124,13 +122,10 @@ jobs:
       - restore_cache:
           keys:
             - backoffice-build-{{ .Revision }}
-      - run:
-          command: docker build -t zenika/marcel-backoffice:dev .
-          working_directory: back-office
-      - run: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-      - run: docker push zenika/marcel-backoffice:dev
+      - run: ${CIRCLE_WORKING_DIRECTORY}/scripts/docker_build.sh zenika/marcel-backoffice
 
   docker_build_frontend:
+    working_directory: frontend
     docker:
       - image: circleci/buildpack-deps:stable-curl
     steps:
@@ -140,10 +135,7 @@ jobs:
           keys:
             - frontend-build-{{ .Revision }}
       - run:
-          command: docker build -t zenika/marcel-frontend:dev .
-          working_directory: frontend
-      - run: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-      - run: docker push zenika/marcel-frontend:dev
+          command: ${CIRCLE_WORKING_DIRECTORY}/scripts/docker_build.sh zenika/marcel-frontend
 
   deploy_integration:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,10 @@ jobs:
     docker:
       - image: circleci/node:12
     steps:
+      - checkout
       - run:
           working_directory: back-office
           command: pwd
-      - checkout
       - restore_cache:
           keys:
           - backoffice-dependencies-{{ checksum "back-office/package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,25 +19,32 @@ jobs:
       - run: go version
 
   build_backoffice:
-    working_directory: /usr/src/app/back-office
+    <<: *defaults
+    working_directory: /usr/src/app
     docker:
       - image: circleci/node:12
     steps:
-      - checkout:
-          path: /usr/src/app
+      - run:
+          working_directory: back-office
+          command: pwd
+      - checkout
       - restore_cache:
           keys:
-          - backoffice-dependencies-{{ checksum "package.json" }}
-      - run: yarn
+          - backoffice-dependencies-{{ checksum "back-office/package.json" }}
+      - run:
+          working_directory: back-office
+          command: yarn
       - save_cache:
           paths:
             - node_modules
-          key: backoffice-dependencies-{{ checksum "package.json" }}
-      - run: yarn build
-      # - save_cache:
-      #     paths:
-      #       - back-office/build
-      #     key: backoffice-build-{{ .Revision }}
+          key: backoffice-dependencies-{{ checksum "back-office/package.json" }}
+      - run:
+          working_directory: back-office
+          command: yarn build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - back-office/build
 
   build_frontend:
     docker:

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -5,16 +5,16 @@ set -e
 set -o pipefail
 # Any subsequent(*) commands which fail will cause the shell script to exit immediately
 
+IMAGE_NAME=${1}
+
 PUSH=false
-if [ "${CIRCLE_BRANCH}" == "master" ] ; then
+if [[ "${CIRCLE_BRANCH}" == "master" || "${CIRCLE_TAG}" != "" ]] ; then
   PUSH=true
 fi
 
-IMAGE_NAME=${1}
-
 IMAGE_VERSION=dev
-if [[ "${CIRCLE_BRANCH}" =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
-  IMAGE_VERSION=${CIRCLE_BRANCH:8} # remove 'release-' from branch name to get version
+if [[ "${CIRCLE_TAG}" != "" ]] ; then
+  IMAGE_VERSION="$CIRCLE_TAG"
   PUSH=true
 fi
 

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Script used to build docker images on CircleCI
+# $1 : image name (without version)
+set -e
+set -o pipefail
+# Any subsequent(*) commands which fail will cause the shell script to exit immediately
+
+PUSH=false
+if [ "${CIRCLE_BRANCH}" == "master" ] ; then
+  PUSH=true
+fi
+
+IMAGE_NAME=${1}
+
+IMAGE_VERSION=dev
+if [[ "${CIRCLE_BRANCH}" =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
+  IMAGE_VERSION=${CIRCLE_BRANCH:8} # remove 'release-' from branch name to get version
+  PUSH=true
+fi
+
+echo "IMAGE_NAME    = ${IMAGE_NAME}"
+echo "IMAGE_VERSION = ${IMAGE_VERSION}"
+echo "PUSH          = ${PUSH}"
+
+# Build docker image.
+docker build -t ${IMAGE_NAME}:${IMAGE_VERSION} .
+
+# Push image to docker hub.
+if [ "${PUSH}" == "true" ] ; then
+  docker login -u ${DOCKER_LOGIN} -p ${DOCKER_PASSWORD}
+  docker push ${IMAGE_NAME}:${IMAGE_VERSION}
+fi


### PR DESCRIPTION
Now built images will be pushed to Docker Hub only if current branch is a master or a release branch. Release branches must be named like 'release-1.2.3'.

The push is done on release branches and not on tags because it would be hard to maintain with CircleCI since a filter must be defined for each build job (https://circleci.com/docs/2.0/workflows/#git-tag-job-execution).