### PR TITLE
:construction_worker: Add script to install on multiple GCP environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,7 @@ filters-master: &filters-master
   branches:
     only:
       - master
+      - install-multi-environment
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,6 @@ filters-master: &filters-master
   branches:
     only:
       - master
-      - install-multi-environment
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,17 +145,19 @@ jobs:
 
   deploy_integration:
     docker:
-      - image: circleci/buildpack-deps:stable-curl
+      - image: google/cloud-sdk:latest
     steps:
       - checkout
       - restore_cache:
           keys:
             - plugins-package-{{ .Revision }}
-      - run: echo $INTEGRATION_SERVER_KEY | sed s/retourligne/\\n/g > integration_key.pem
-      - run: chmod 400 integration_key.pem
-      - run: scp -o StrictHostKeyChecking=no -i integration_key.pem plugins.tar.gz ubuntu@preprod.marcel.zenika.com:~/
-      - run: ssh -o StrictHostKeyChecking=no -i integration_key.pem ubuntu@preprod.marcel.zenika.com "./MARCEL/deploy.sh"
-      - run: rm -f integration_key.pem
+      - run: ./scripts/install.sh
+      - run: 
+          command: rm -rf ${HOME}/.ssh
+          when: always
+      - run: 
+          command: rm -f ${HOME}/gcloud-service-key.json
+          when: always
 
 filters-all: &filters-all
   tags:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
-# Script used to install MARCEL on GCP virtual machines
+# Script used to install marcel on GCP virtual machines
 # $1 : version to install
 set -e
 set -o pipefail
 # Any subsequent(*) commands which fail will cause the shell script to exit immediately
 
-
 if [ ! -z "${1}" ] ; then
   VERSION=${1}
-elif [[ "${CIRCLE_BRANCH}" =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
-  VERSION=${CIRCLE_BRANCH:8} # remove 'release-' from branch name to get version
+elif [[ "${CIRCLE_TAG}" != "" ]] ; then
+  VERSION=${CIRCLE_TAG}
 else
   VERSION=dev
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Script used to install MARCEL on GCP virtual machines
+# $1 : version to install
+set -e
+set -o pipefail
+# Any subsequent(*) commands which fail will cause the shell script to exit immediately
+
+
+if [ ! -z "${1}" ] ; then
+  VERSION=${1}
+elif [[ "${CIRCLE_BRANCH}" =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
+  VERSION=${CIRCLE_BRANCH:8} # remove 'release-' from branch name to get version
+else
+  VERSION=dev
+fi
+
+if [ "${CI}" == true ] ; then
+  echo "authenticate to google cloud"
+  echo ${GCLOUD_SERVICE_KEY} | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
+  gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+  gcloud config set project ${GCLOUD_PROJECT_ID}
+
+  echo "copy ssh key"
+  mkdir -p ${HOME}/.ssh
+  chmod 700 ${HOME}/.ssh
+  echo ${GCLOUD_SSH_KEY} | base64 --decode --ignore-garbage > ${HOME}/.ssh/google_compute_engine
+  chmod 600 ${HOME}/.ssh/google_compute_engine
+  echo ${GCLOUD_SSH_PUB_KEY} | base64 --decode --ignore-garbage > ${HOME}/.ssh/google_compute_engine.pub
+  chmod 644 ${HOME}/.ssh/google_compute_engine.pub
+fi
+
+# Use gcloud command to list servers using this version
+INSTANCES=$(gcloud compute instances list --filter="labels.version = ${VERSION}" --uri)
+
+# Do install on each instance found
+PATTERN="https://www.googleapis.com/compute/v1/projects/zen-dashboard/zones/\([^/]*\)/instances/\([^/]*\)"
+for url in ${INSTANCES} ; do
+  zone=$(echo "${url}" | sed -e "s,${PATTERN},\1,")
+  instance=$(echo "${url}" | sed -e "s,${PATTERN},\2,g")
+  echo "install version ${VERSION} on instance ${zone}/${instance}"
+  gcloud compute scp /home/circleci/project/plugins.tar.gz "ubuntu@${instance}:~/" --strict-host-key-checking=no --zone="${zone}"
+  gcloud compute ssh "ubuntu@${instance}" --strict-host-key-checking=no --zone="${zone}" -- "./MARCEL/deploy.sh"
+done

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,5 +38,5 @@ for url in ${INSTANCES} ; do
   instance=$(echo "${url}" | sed -e "s,${PATTERN},\2,g")
   echo "install version ${VERSION} on instance ${zone}/${instance}"
   gcloud compute scp /home/circleci/project/plugins.tar.gz "ubuntu@${instance}:~/" --strict-host-key-checking=no --zone="${zone}"
-  gcloud compute ssh "ubuntu@${instance}" --strict-host-key-checking=no --zone="${zone}" -- "./MARCEL/deploy.sh"
+  gcloud compute ssh "ubuntu@${instance}" --strict-host-key-checking=no --zone="${zone}" -- "./marcel-${VERSION}/deploy.sh"
 done


### PR DESCRIPTION
Add script install.sh to install custom version on GCP instances. This script use instance tag named "version" to identify servers on which install must be done.

The ssh key used in this script will be automatically deployed in instances by compute engine (it was added to project metadata https://console.cloud.google.com/compute/metadata/sshKeys?project=zen-dashboard).