### PR TITLE
:sparkles: Front download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           paths:
             - /go/pkg/mod
       - attach_workspace:
-          at: /go/app
+          at: .
       - run: go test .
       - run: packr
       - run: CGO_ENABLED=0 go build -ldflags '-extldflags "-static" -X github.com/Zenika/marcel/version.Version=${CIRCLE_TAG:-$CIRCLE_BRANCH} -X github.com/Zenika/marcel/version.Revision=$CIRCLE_SHA1' -tags 'osusergo netgo' -o marcel
@@ -102,7 +102,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - attach_workspace:
-          at: /tmp/app
+          at: .
       - run: ${CIRCLE_WORKING_DIRECTORY}/scripts/docker_build.sh zenika/marcel
 
   archive_backoffice:
@@ -140,6 +140,17 @@ filters-master: &filters-master
   branches:
     only:
       - master
+filters-tag: &filters-tag
+  branches:
+    ignore: /.*/
+  tags:
+    only: /.*/
+filters-master-tag: &filters-master-tag
+  branches:
+    only:
+      - master
+  tags:
+    only: /.*/
 
 workflows:
   version: 2
@@ -159,11 +170,11 @@ workflows:
             - build_backoffice
             - build_frontend
       - docker_build_marcel:
-          filters: *filters-all
+          filters: *filters-master-tag
           requires:
             - build_marcel
       - archive_backoffice:
-          filters: *filters-all # FIXME tobe changed
+          filters: *filters-tag
           requires:
             - build_backoffice
       - deploy_integration:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
     executor: std-executor
     steps:
       - attach_workspace:
-          at: /tmp/app
+          at: .
       - run:
           command: tar czf ../marcel-backoffice.tgz *
           working_directory: backoffice/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
       - run: go test .
       - run: go get -u github.com/gobuffalo/packr/packr
       - run: packr
-      - run: CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -tags 'osusergo netgo' -o marcel
+      - run: CGO_ENABLED=0 go build -ldflags '-extldflags "-static" -X github.com/Zenika/marcel/version.Version=${CIRCLE_TAG:-$CIRCLE_BRANCH} -X github.com/Zenika/marcel/version.Revision=$CIRCLE_SHA1' -tags 'osusergo netgo' -o marcel
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,28 @@ jobs:
           at: .
       - run: go test .
       - run: packr
-      - run: CGO_ENABLED=0 go build -ldflags '-extldflags "-static" -X github.com/Zenika/marcel/version.Version=${CIRCLE_TAG:-$CIRCLE_BRANCH} -X github.com/Zenika/marcel/version.Revision=$CIRCLE_SHA1' -tags 'osusergo netgo' -o marcel
+      - run: "CGO_ENABLED=0 go build -ldflags \"-extldflags \\\"-static\\\" -X github.com/Zenika/marcel/version.Version=$CIRCLE_BRANCH -X github.com/Zenika/marcel/version.Revision=$CIRCLE_SHA1\" -tags \"osusergo netgo\" -o marcel"
+      - persist_to_workspace:
+          root: .
+          paths:
+            - Dockerfile
+            - marcel
+
+  build_marcel_nopackr:
+    executor: go_executor
+    steps:
+      - checkout
+      - restore_cache:
+          key: marcel-go-deps-{{ checksum "go.mod" }}
+      - run: go mod download
+      - save_cache:
+          key: marcel-go-deps-{{ checksum "go.mod" }}
+          paths:
+            - /go/pkg/mod
+      - attach_workspace:
+          at: .
+      - run: go test .
+      - run: "CGO_ENABLED=0 go build -ldflags \"-extldflags \\\"-static\\\" -X github.com/Zenika/marcel/version.Version=$CIRCLE_TAG -X github.com/Zenika/marcel/version.Revision=$CIRCLE_SHA1\" -tags \"osusergo netgo nopackr\" -o marcel"
       - persist_to_workspace:
           root: .
           paths:
@@ -118,6 +139,19 @@ jobs:
           paths:
             - backoffice/marcel-backoffice.tgz
 
+  archive_frontend:
+    executor: std_executor
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          command: tar czf ../marcel-frontend.tgz *
+          working_directory: frontend/build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - frontend/marcel-frontend.tgz
+
   deploy_integration:
     executor: gcloud_executor
     steps:
@@ -139,7 +173,8 @@ jobs:
       - attach_workspace:
           at: .
       - run: go get github.com/tcnksm/ghr
-      - run: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_TAG} backoffice/marcel-backoffice.tgz
+      - run: mkdir assets && mv backoffice/marcel-backoffice.tgz frontend/marcel-frontend.tgz marcel assets
+      - run: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_TAG} assets
 
 filters-all: &filters-all
   tags:
@@ -173,7 +208,11 @@ workflows:
       - build_frontend:
           filters: *filters-all
       - build_marcel:
-          filters: *filters-all
+          requires:
+            - build_backoffice
+            - build_frontend
+      - build_marcel_nopackr:
+          filters: *filters-tag
           requires:
             - build_backoffice
             - build_frontend
@@ -185,6 +224,10 @@ workflows:
           filters: *filters-tag
           requires:
             - build_backoffice
+      - archive_frontend:
+          filters: *filters-tag
+          requires:
+            - build_frontend
       - deploy_integration:
           filters: *filters-master
           requires:
@@ -192,4 +235,6 @@ workflows:
       - publish_github_release:
           filters: *filters-tag
           requires:
+            - build_marcel_nopackr
             - archive_backoffice
+            - archive_frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ workflows:
           requires:
             - build_marcel
       - archive_backoffice:
-          filters: *filters-master # FIXME tobe changed
+          filters: *filters-all # FIXME tobe changed
           requires:
             - build_backoffice
       - deploy_integration:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,5 @@
-defaults: &defaults
-  working_directory: /tmp
-  docker:
-    - image: circleci/buildpack-deps:stable-curl
-
 version: 2
+
 jobs:
   debug_node:
     docker:
@@ -19,7 +15,6 @@ jobs:
       - run: go version
 
   build_backoffice:
-    <<: *defaults
     docker:
       - image: circleci/node:12
     working_directory: /home/circleci/app
@@ -44,7 +39,6 @@ jobs:
             - backoffice/build
 
   build_frontend:
-    <<: *defaults
     docker:
       - image: circleci/node:12
     working_directory: /home/circleci/app
@@ -69,7 +63,6 @@ jobs:
             - frontend/build
 
   build_marcel:
-    <<: *defaults
     working_directory: /go/app
     docker:
       - image: circleci/golang:1.12
@@ -95,7 +88,6 @@ jobs:
             - marcel
 
   docker_build_marcel:
-    <<: *defaults
     docker:
       - image: circleci/buildpack-deps:stable-curl
     working_directory: /tmp/app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,17 @@ jobs:
           paths:
             - frontend/marcel-frontend.tgz
 
+  archive_marcel:
+    executor: std_executor
+    steps:
+      - attach_workspace:
+          at: .
+      - run: tar czf marcel.tgz marcel
+      - persist_to_workspace:
+          root: .
+          paths:
+            - marcel.tgz
+
   deploy_integration:
     executor: gcloud_executor
     steps:
@@ -161,7 +172,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: go get github.com/tcnksm/ghr
-      - run: mkdir assets && mv backoffice/marcel-backoffice.tgz frontend/marcel-frontend.tgz marcel assets
+      - run: mkdir assets && mv backoffice/marcel-backoffice.tgz frontend/marcel-frontend.tgz marcel.tgz assets
       - run: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_TAG} assets
 
 filters-all: &filters-all
@@ -213,6 +224,10 @@ workflows:
           filters: *filters-tag
           requires:
             - build_frontend
+      - archive_marcel:
+          filters: *filters-tag
+          requires:
+            - build_marcel_nopackr
       - deploy_integration:
           filters: *filters-master
           requires:
@@ -220,6 +235,6 @@ workflows:
       - publish_github_release:
           filters: *filters-tag
           requires:
-            - build_marcel_nopackr
             - archive_backoffice
             - archive_frontend
+            - archive_marcel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,14 +77,8 @@ jobs:
     executor: go_executor
     steps:
       - checkout
-      - restore_cache:
-          key: marcel-go-deps-{{ checksum "go.mod" }}
       - run: go mod download
       - run: go get -u github.com/gobuffalo/packr/packr
-      - save_cache:
-          key: marcel-go-deps-{{ checksum "go.mod" }}
-          paths:
-            - /go/pkg/mod
       - attach_workspace:
           at: .
       - run: go test .
@@ -100,13 +94,7 @@ jobs:
     executor: go_executor
     steps:
       - checkout
-      - restore_cache:
-          key: marcel-go-deps-{{ checksum "go.mod" }}
       - run: go mod download
-      - save_cache:
-          key: marcel-go-deps-{{ checksum "go.mod" }}
-          paths:
-            - /go/pkg/mod
       - attach_workspace:
           at: .
       - run: go test .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,9 +213,6 @@ workflows:
             - build_frontend
       - build_marcel_nopackr:
           filters: *filters-tag
-          requires:
-            - build_backoffice
-            - build_frontend
       - docker_build_marcel:
           filters: *filters-master-tag
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - marcel/marcel-backoffice.tgz
+            - backoffice/marcel-backoffice.tgz
 
   deploy_integration:
     executor: gcloud-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,35 +1,48 @@
-version: 2
+version: 2.1
+
+executors:
+  node-executor:
+    docker:
+      - image: circleci/node:12
+    working_directory: /home/circleci/app
+  go-executor:
+    docker:
+      - image: circleci/golang:1.12
+    working_directory: /go/app
+  std-executor:
+    docker:
+      - image: circleci/buildpack-deps:stable-curl
+    working_directory: /tmp/app
+  gcloud-executor:
+    docker:
+      - image: google/cloud-sdk:latest
 
 jobs:
   debug_node:
-    docker:
-      - image: circleci/node:12
+    executor: node-executor
     steps:
       - run: node --version
       - run: yarn --version
 
   debug_go:
-    docker:
-      - image: circleci/golang:1.12
+    executor: go-executor
     steps:
       - run: go version
 
   build_backoffice:
-    docker:
-      - image: circleci/node:12
-    working_directory: /home/circleci/app
+    executor: node-executor
     steps:
       - checkout
       - restore_cache:
           keys:
-            - backoffice-deps-{{ checksum "backoffice/package.json" }}
+            - marcel-backoffice-deps-{{ checksum "backoffice/package.json" }}
       - run:
           command: yarn
           working_directory: backoffice
       - save_cache:
           paths:
             - backoffice/node_modules
-          key: backoffice-deps-{{ checksum "backoffice/package.json" }}
+          key: marcel-backoffice-deps-{{ checksum "backoffice/package.json" }}
       - run:
           command: yarn build
           working_directory: backoffice
@@ -39,21 +52,19 @@ jobs:
             - backoffice/build
 
   build_frontend:
-    docker:
-      - image: circleci/node:12
-    working_directory: /home/circleci/app
+    executor: node-executor
     steps:
       - checkout
       - restore_cache:
           keys:
-            - frontend-deps-{{ checksum "frontend/package.json" }}
+            - marcel-frontend-deps-{{ checksum "frontend/package.json" }}
       - run:
           command: yarn
           working_directory: frontend
       - save_cache:
           paths:
             - frontend/node_modules
-          key: frontend-deps-{{ checksum "frontend/package.json" }}
+          key: marcel-frontend-deps-{{ checksum "frontend/package.json" }}
       - run:
           command: yarn build
           working_directory: frontend
@@ -63,22 +74,20 @@ jobs:
             - frontend/build
 
   build_marcel:
-    working_directory: /go/app
-    docker:
-      - image: circleci/golang:1.12
+    executor: go-executor
     steps:
       - checkout
       - restore_cache:
-          key: marcel-deps-{{ checksum "go.mod" }}
+          key: marcel-go-deps-{{ checksum "go.mod" }}
       - run: go mod download
+      - run: go get -u github.com/gobuffalo/packr/packr
       - save_cache:
-          key: marcel-deps-{{ checksum "go.mod" }}
+          key: marcel-go-deps-{{ checksum "go.mod" }}
           paths:
             - /go/pkg/mod
       - attach_workspace:
           at: /go/app
       - run: go test .
-      - run: go get -u github.com/gobuffalo/packr/packr
       - run: packr
       - run: CGO_ENABLED=0 go build -ldflags '-extldflags "-static" -X github.com/Zenika/marcel/version.Version=${CIRCLE_TAG:-$CIRCLE_BRANCH} -X github.com/Zenika/marcel/version.Revision=$CIRCLE_SHA1' -tags 'osusergo netgo' -o marcel
       - persist_to_workspace:
@@ -88,9 +97,7 @@ jobs:
             - marcel
 
   docker_build_marcel:
-    docker:
-      - image: circleci/buildpack-deps:stable-curl
-    working_directory: /tmp/app
+    executor: std-executor
     steps:
       - checkout
       - setup_remote_docker
@@ -98,9 +105,21 @@ jobs:
           at: /tmp/app
       - run: ${CIRCLE_WORKING_DIRECTORY}/scripts/docker_build.sh zenika/marcel
 
+  archive_backoffice:
+    executor: std-executor
+    steps:
+      - attach_workspace:
+          at: /tmp/app
+      - run:
+          command: tar czf ../marcel-backoffice.tgz
+          working_directory: backoffice/build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - marcel/marcel-backoffice.tgz
+
   deploy_integration:
-    docker:
-      - image: google/cloud-sdk:latest
+    executor: gcloud-executor
     steps:
       - checkout
       - restore_cache:
@@ -143,6 +162,10 @@ workflows:
           filters: *filters-all
           requires:
             - build_marcel
+      - archive_backoffice:
+          filters: *filters-master # FIXME tobe changed
+          requires:
+            - build_backoffice
       - deploy_integration:
           filters: *filters-master
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
       - attach_workspace:
           at: /tmp/app
       - run:
-          command: tar czf ../marcel-backoffice.tgz
+          command: tar czf ../marcel-backoffice.tgz *
           working_directory: backoffice/build
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,14 +76,14 @@ jobs:
   build_marcel:
     executor: go_executor
     steps:
-      - checkout
-      - run: go mod download
       - run: go get -u github.com/gobuffalo/packr/packr
+      - checkout
       - attach_workspace:
           at: .
-      - run: go test .
+      - run: go mod download
       - run: packr
-      - run: "CGO_ENABLED=0 go build -ldflags \"-extldflags \\\"-static\\\" -X github.com/Zenika/marcel/version.Version=$CIRCLE_BRANCH -X github.com/Zenika/marcel/version.Revision=$CIRCLE_SHA1\" -tags \"osusergo netgo\" -o marcel"
+      - run: go test -mod=readonly .
+      - run: "CGO_ENABLED=0 go build -mod=readonly -ldflags \"-extldflags \\\"-static\\\" -X github.com/Zenika/marcel/version.Version=$CIRCLE_BRANCH -X github.com/Zenika/marcel/version.Revision=$CIRCLE_SHA1\" -tags \"osusergo netgo\" -o marcel"
       - persist_to_workspace:
           root: .
           paths:
@@ -94,11 +94,11 @@ jobs:
     executor: go_executor
     steps:
       - checkout
-      - run: go mod download
       - attach_workspace:
           at: .
-      - run: go test .
-      - run: "CGO_ENABLED=0 go build -ldflags \"-extldflags \\\"-static\\\" -X github.com/Zenika/marcel/version.Version=$CIRCLE_TAG -X github.com/Zenika/marcel/version.Revision=$CIRCLE_SHA1\" -tags \"osusergo netgo nopackr\" -o marcel"
+      - run: go mod download
+      - run: go test -mod=readonly .
+      - run: "CGO_ENABLED=0 go build -mod=readonly -ldflags \"-extldflags \\\"-static\\\" -X github.com/Zenika/marcel/version.Version=$CIRCLE_TAG -X github.com/Zenika/marcel/version.Revision=$CIRCLE_SHA1\" -tags \"osusergo netgo nopackr\" -o marcel"
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
     working_directory: /home/circleci/app
   go-executor:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
     working_directory: /go/app
   std-executor:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,36 +1,36 @@
 version: 2.1
 
 executors:
-  node-executor:
+  node_executor:
     docker:
       - image: circleci/node:12
     working_directory: /home/circleci/app
-  go-executor:
+  go_executor:
     docker:
       - image: circleci/golang:1.13
     working_directory: /go/app
-  std-executor:
+  std_executor:
     docker:
       - image: circleci/buildpack-deps:stable-curl
     working_directory: /tmp/app
-  gcloud-executor:
+  gcloud_executor:
     docker:
       - image: google/cloud-sdk:latest
 
 jobs:
   debug_node:
-    executor: node-executor
+    executor: node_executor
     steps:
       - run: node --version
       - run: yarn --version
 
   debug_go:
-    executor: go-executor
+    executor: go_executor
     steps:
       - run: go version
 
   build_backoffice:
-    executor: node-executor
+    executor: node_executor
     steps:
       - checkout
       - restore_cache:
@@ -52,7 +52,7 @@ jobs:
             - backoffice/build
 
   build_frontend:
-    executor: node-executor
+    executor: node_executor
     steps:
       - checkout
       - restore_cache:
@@ -74,7 +74,7 @@ jobs:
             - frontend/build
 
   build_marcel:
-    executor: go-executor
+    executor: go_executor
     steps:
       - checkout
       - restore_cache:
@@ -97,7 +97,7 @@ jobs:
             - marcel
 
   docker_build_marcel:
-    executor: std-executor
+    executor: std_executor
     steps:
       - checkout
       - setup_remote_docker
@@ -106,7 +106,7 @@ jobs:
       - run: ${CIRCLE_WORKING_DIRECTORY}/scripts/docker_build.sh zenika/marcel
 
   archive_backoffice:
-    executor: std-executor
+    executor: std_executor
     steps:
       - attach_workspace:
           at: .
@@ -119,7 +119,7 @@ jobs:
             - backoffice/marcel-backoffice.tgz
 
   deploy_integration:
-    executor: gcloud-executor
+    executor: gcloud_executor
     steps:
       - checkout
       - restore_cache:
@@ -133,6 +133,14 @@ jobs:
           command: rm -f ${HOME}/gcloud-service-key.json
           when: always
 
+  publish_github_release:
+    executor: go_executor
+    steps:
+      - attach_workspace:
+          at: .
+      - run: go get github.com/tcnksm/ghr
+      - run: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_TAG} backoffice/marcel-backoffice.tgz
+
 filters-all: &filters-all
   tags:
     only: /.*/
@@ -145,7 +153,7 @@ filters-tag: &filters-tag
     ignore: /.*/
   tags:
     only: /.*/
-filters-master-tag: &filters-master-tag
+filters-master_tag: &filters-master-tag
   branches:
     only:
       - master
@@ -181,3 +189,7 @@ workflows:
           filters: *filters-master
           requires:
             - docker_build_marcel
+      - publish_github_release:
+          filters: *filters-tag
+          requires:
+            - archive_backoffice

--- a/api/api.go
+++ b/api/api.go
@@ -82,7 +82,7 @@ func (a *API) waitSignal() {
 	}()
 }
 
-func (a *API) ConfigureRouter(r *mux.Router) {
+func (a *API) ConfigureRouter(r *mux.Router) error {
 	b := r.PathPrefix(config.Config().API().BasePath()).Subrouter()
 
 	b.Use(auth.Middleware)
@@ -133,6 +133,8 @@ func (a *API) ConfigureRouter(r *mux.Router) {
 	user := users.PathPrefix("/{userID}").Subrouter()
 	user.HandleFunc("", deleteUserHandler).Methods("DELETE")
 	user.HandleFunc("", updateUserHandler).Methods("PUT")
+
+	return nil
 }
 
 func (a *API) initializeServices() {

--- a/backoffice/backoffice.go
+++ b/backoffice/backoffice.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gobuffalo/packr"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 
@@ -65,7 +64,7 @@ func fileHandler(base string) http.Handler {
 		http.FileServer(
 			httputil.NewNotFoundRewriter(
 				httputil.NewTemplater(
-					packr.NewBox("../backoffice/build/"),
+					fs,
 					[]string{index},
 					map[string]string{"REACT_APP_BASE": base},
 				),

--- a/backoffice/backoffice_archive.go
+++ b/backoffice/backoffice_archive.go
@@ -1,0 +1,88 @@
+// +build nopackr
+
+package backoffice
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/Zenika/marcel/config"
+	"github.com/Zenika/marcel/version"
+)
+
+func initFs() (http.FileSystem, error) {
+	url := fmt.Sprintf("https://github.com/Zenika/marcel/releases/download/%s/marcel-backoffice.tgz", version.Version)
+
+	log.Infof("Fetching %s", url)
+	res, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	path := filepath.Join(config.Config().API().DataDir(), "backoffice", version.Version)
+
+	if err := os.RemoveAll(path); err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(path, os.ModePerm); err != nil { // FIXME is ModePerm OK ?
+		return nil, err
+	}
+
+	log.Infoln("Uncompressing marcel-backoffice.tgz")
+
+	gz, err := gzip.NewReader(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		info := hdr.FileInfo()
+		filePath := filepath.Join(path, hdr.Name)
+
+		if info.IsDir() {
+			if err := os.Mkdir(filePath, os.ModePerm); err != nil { // FIXME is ModePerm OK ?
+				return nil, err
+			}
+		} else {
+			if err := copyToFile(filePath, tr); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return http.Dir(path), nil
+}
+
+func copyToFile(name string, r io.Reader) error {
+	f, err := os.Create(name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, r); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/backoffice/backoffice_box.go
+++ b/backoffice/backoffice_box.go
@@ -2,6 +2,12 @@
 
 package backoffice
 
-import "github.com/gobuffalo/packr"
+import (
+	"net/http"
 
-var fs = packr.NewBox("../backoffice/build/")
+	"github.com/gobuffalo/packr"
+)
+
+func initFs() (http.FileSystem, error) {
+	return packr.NewBox("../backoffice/build/"), nil
+}

--- a/backoffice/backoffice_box.go
+++ b/backoffice/backoffice_box.go
@@ -1,0 +1,7 @@
+// +build !nopackr
+
+package backoffice
+
+import "github.com/gobuffalo/packr"
+
+var fs = packr.NewBox("../backoffice/build/")

--- a/cmd/standalone.go
+++ b/cmd/standalone.go
@@ -26,8 +26,8 @@ func init() {
 			cfg.Debug()
 		},
 
-		Run: func(_ *cobra.Command, _ []string) {
-			standalone.Start()
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return standalone.Start()
 		},
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Zenika/marcel/version"
+)
+
+func init() {
+	Marcel.AddCommand(&cobra.Command{
+		Use:   "version",
+		Short: "Displays version information",
+		Args:  cobra.NoArgs,
+
+		Run: func(_ *cobra.Command, _ []string) {
+			fmt.Printf("%s rev: %s\n", version.Version, version.Revision)
+		},
+	})
+}

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gobuffalo/packr"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 
@@ -30,7 +29,11 @@ func ConfigureRouter(r *mux.Router) error {
 	var b = r.PathPrefix(httputil.TrimTrailingSlash(base)).Subrouter()
 
 	b.HandleFunc("/config", configHandler).Methods("GET")
-	b.PathPrefix("/").Handler(fileHandler(base))
+	fh, err := fileHandler(base)
+	if err != nil {
+		return err
+	}
+	b.PathPrefix("/").Handler(fh)
 
 	return nil
 }
@@ -50,15 +53,19 @@ func configHandler(res http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func fileHandler(base string) http.Handler {
+func fileHandler(base string) (http.Handler, error) {
+	fs, err := initFs()
+	if err != nil {
+		return nil, err
+	}
 	return http.StripPrefix(
 		base,
 		http.FileServer(
 			httputil.NewTemplater(
-				packr.NewBox("../frontend/build/"),
+				fs,
 				[]string{"/index.html"},
 				map[string]string{"REACT_APP_BASE": base},
 			),
 		),
-	)
+	), nil
 }

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -24,13 +24,15 @@ func Start() error {
 	return http.ListenAndServe(fmt.Sprintf(":%d", config.Config().Frontend().Port()), r)
 }
 
-func ConfigureRouter(r *mux.Router) {
+func ConfigureRouter(r *mux.Router) error {
 	var base = httputil.NormalizeBase(config.Config().Frontend().BasePath())
 
 	var b = r.PathPrefix(httputil.TrimTrailingSlash(base)).Subrouter()
 
 	b.HandleFunc("/config", configHandler).Methods("GET")
 	b.PathPrefix("/").Handler(fileHandler(base))
+
+	return nil
 }
 
 func configHandler(res http.ResponseWriter, req *http.Request) {

--- a/frontend/frontend_archive.go
+++ b/frontend/frontend_archive.go
@@ -1,6 +1,6 @@
 // +build nopackr
 
-package backoffice
+package frontend
 
 import (
 	"fmt"
@@ -13,8 +13,8 @@ import (
 )
 
 func initFs() (http.FileSystem, error) {
-	url := fmt.Sprintf("https://github.com/Zenika/marcel/releases/download/%s/marcel-backoffice.tgz", version.Version)
-	path := filepath.Join(config.Config().API().DataDir(), "backoffice", version.Version)
+	url := fmt.Sprintf("https://github.com/Zenika/marcel/releases/download/%s/marcel-frontend.tgz", version.Version)
+	path := filepath.Join(config.Config().API().DataDir(), "frontend", version.Version)
 
 	if err := httputil.DownloadTgzToDir(url, path); err != nil {
 		return nil, err

--- a/frontend/frontend_box.go
+++ b/frontend/frontend_box.go
@@ -1,0 +1,13 @@
+// +build !nopackr
+
+package frontend
+
+import (
+	"net/http"
+
+	"github.com/gobuffalo/packr"
+)
+
+func initFs() (http.FileSystem, error) {
+	return packr.NewBox("../frontend/build/"), nil
+}

--- a/httputil/downloadTgzToDir.go
+++ b/httputil/downloadTgzToDir.go
@@ -1,0 +1,78 @@
+package httputil
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func DownloadTgzToDir(url, path string) error {
+	log.Infof("Fetching %s...", url)
+	res, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if err := os.RemoveAll(path); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		return err
+	}
+
+	log.Infof("Uncompressing %s...", url)
+
+	gz, err := gzip.NewReader(res.Body)
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		info := hdr.FileInfo()
+		filePath := filepath.Join(path, hdr.Name)
+
+		if info.IsDir() {
+			if err := os.Mkdir(filePath, os.ModePerm); err != nil {
+				return err
+			}
+		} else {
+			if err := copyToFile(filePath, tr); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func copyToFile(name string, r io.Reader) error {
+	f, err := os.Create(name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, r); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/httputil/downloadTgzToDir.go
+++ b/httputil/downloadTgzToDir.go
@@ -3,6 +3,7 @@ package httputil
 import (
 	"archive/tar"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -18,6 +19,10 @@ func DownloadTgzToDir(url, path string) error {
 		return err
 	}
 	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s returned status %d", url, res.StatusCode)
+	}
 
 	if err := os.RemoveAll(path); err != nil {
 		return err

--- a/standalone/standalone.go
+++ b/standalone/standalone.go
@@ -18,7 +18,7 @@ import (
 
 type routerConfigurer struct {
 	base      string
-	configure func(*mux.Router)
+	configure func(*mux.Router) error
 }
 
 type routerConfigurers []routerConfigurer
@@ -37,7 +37,7 @@ func (configurers routerConfigurers) Swap(i, j int) {
 	configurers[i], configurers[j] = configurers[j], configurers[i]
 }
 
-func Start() {
+func Start() error {
 	var a = api.New()
 	a.Initialize()
 
@@ -52,10 +52,12 @@ func Start() {
 	sort.Sort(configurers)
 
 	for _, configurer := range configurers {
-		configurer.configure(r)
+		if err := configurer.configure(r); err != nil {
+			return err
+		}
 	}
 
 	log.Infof("Starting standalone server on port %d...", config.Config().Standalone().Port())
 
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", config.Config().Standalone().Port()), r))
+	return http.ListenAndServe(fmt.Sprintf(":%d", config.Config().Standalone().Port()), r)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+var (
+	Version  = "dev"
+	Revision string
+)


### PR DESCRIPTION
See result here: https://github.com/Zenika/marcel/releases/tag/v3.0.0-alpha.5

 - New build tag `nopackr` to build without embedding fronts
 - Download fronts from github release on startup (when necessary)

For now fronts are downloaded each time (even if already on disk)

CI:
 - On branches, only build
 - On master, build with packr, then deploy on preprod
 - On tags, build w/o packr, then attach assets to new release